### PR TITLE
Fixing deprecation notice

### DIFF
--- a/templates/locale.erb
+++ b/templates/locale.erb
@@ -1,2 +1,2 @@
 # This file is managed by Puppet.
-LANG=<%= default_locale %>
+LANG=<%= @default_locale %>

--- a/templates/locale.gen.erb
+++ b/templates/locale.gen.erb
@@ -1,5 +1,5 @@
 # File managed by puppet
 
-<% locales.each do |locale| -%>
+<% @locales.each do |locale| -%>
 <%= locale %>
 <% end -%>


### PR DESCRIPTION
Simple update to the template to fix this message (run in Puppet 3.3.1).

```
Warning: Variable access via 'locales' is deprecated. Use '@locales' instead. template[/tmp/vagrant-puppet/modules-1/locales/templates/locale.gen.erb]:3
Warning: Variable access via 'default_locale' is deprecated. Use '@default_locale' instead. template[/tmp/vagrant-puppet/modules-1/locales/templates/locale.erb]:2
```
