### PR TITLE
Make sure that the executables are able to find other executables.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,9 @@ class locales (
     }
   }
 
+  # Make sure that the executables are able to find other executables.
+  Exec { path => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin' }
+
   exec { 'locale-gen':
     command     => $locale_gen_cmd,
     refreshonly => true,


### PR DESCRIPTION
As I assumed, setting a `path` fixes #11
