### PR TITLE
Allow setting the various LC_* env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,26 @@ Advanced usage allows you to select which locales will be configured as well as 
   }
 ```
 
+You can also set specific locale environment variables. See the locale man-page
+for available LC_* environment variables and their descriptions:
+
+```
+  class { 'locales':
+    default_locale  => 'en_US.UTF-8',
+    locales         => ['en_US.UTF-8 UTF-8', 'fr_CH.UTF-8 UTF-8', 'en_DK.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8' ],
+    lc_time         => 'en_DK.UTF-8',
+    lc_paper        => 'de_DE.UTF-8',
+  }
+```
+
 ## Other class parameters
 * locales: Name of locales to generate, default: ['en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8']
 * ensure: present or absent, default: present
 * default_locale: string, default: 'C'. Set the default locale.
+* lc_ctype: string, default: undef. Character classification and case conversion.
+* lc_collate: string, default: undef. Collation order.
+* lc_time: string, default: undef. Date and time formats.
+* ...
 * autoupgrade: true or false, default: false. Auto-upgrade package, if there is a newer version.
 * package: string, default: OS specific. Set package name, if platform is not supported.
 * config_file: string, default: OS specific. Set config_file, if platform is not supported.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,71 @@
 #     Ensure if present or absent.
 #     Default: present
 #
+#   [*default_locale*]
+#     The value of the LANG environment variable. Used by the locale system as
+#     default for other LC_* variables that have not been set explicitly. When
+#     setting this make sure the desired locale exists by specifying it in the
+#     *locales* parameter.
+#     Example: default_locale => 'en_GB.UTF-8'
+#     Default: undef
+#
+#   [*lc_ctype*]
+#     Character classification and case conversion. How characters are
+#     classified as letters, numbers etc. This determines things like how
+#     characters are converted between upper and lower case.
+#     Default: undef
+#
+#   [*lc_collate*]
+#     Collation order. How strings (file names...) are alphabetically sorted.
+#     Using the "C" or "POSIX" locale here results in a strcmp()-like sort
+#     order, which may be preferable to language-specific locales.
+#     Default: undef
+#
+#   [*lc_time*]
+#     Date and time formats. How your time and date are formatted. Use for
+#     example "en_DK.UTF-8" to get a 24-hour-clock in some programs.
+#     Default: undef
+#
+#   [*lc_numeric*]
+#     Non-monetary numeric formats. How you format your numbers. For example,
+#     in many countries a period (.) is used as a decimal separator, while
+#     others use a comma (,).
+#     Default: undef
+#
+#   [*lc_monetary*]
+#     Monetary formats. What currency you use, its name, and its symbol.
+#     Default: undef
+#
+#   [*lc_messages*]
+#     Formats of informative and diagnostic messages and interactive responses.
+#     Default: undef
+#
+#   [*lc_paper*]
+#     Paper size.
+#     Default: undef
+#
+#   [*lc_name*]
+#     Name formats. How names are represented (surname first or last, etc.).
+#     Default: undef
+#
+#   [*lc_address*]
+#     Address formats and location information. How addresses are formatted
+#     (country first or last, where zip code goes etc.).
+#     Default: undef
+#
+#   [*lc_telephone*]
+#     Telephone number formats.
+#     Default: undef
+#
+#   [*lc_measurement*]
+#     Measurement units (Metric or Other). What units of measurement are used
+#     (feet, meters, pounds, kilos etc.).
+#     Default: undef
+#
+#   [*lc_identification*]
+#     Metadata about the locale information.
+#     Default: undef
+#
 #   [*autoupgrade*]
 #     Upgrade package automatically, if there is a newer version.
 #     Default: false
@@ -31,26 +96,42 @@
 #     Default: auto-set, platform specific
 #
 # Actions:
-#   Installs locales package and generates specified locales
+#   Installs locales package, generates specified locales and sets
+#   locale-related environment variables in the appropriate system-wide
+#   configuration file.
 #
 # Requires:
 #   Nothing
 #
 # Sample Usage:
 #   class { 'locales':
-#     locales => [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', 'en_GB.UTF-8 UTF-8', ],
+#     locales        => [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', 'en_GB.UTF-8 UTF-8', ],
+#     default_locale => 'en_GB.UTF-8',
+#     lc_time        => 'en_DK.UTF-8'
 #   }
 #
 # [Remember: No empty lines between comments and class definition]
 class locales (
-  $locales = [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', ],
-  $ensure = 'present',
-  $default_locale = undef,
-  $autoupgrade = false,
-  $package = $locales::params::package,
-  $config_file = $locales::params::config_file,
-  $locale_gen_cmd = $locales::params::locale_gen_cmd,
-  $default_file = $locales::params::default_file,
+  $locales           = [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', ],
+  $ensure            = 'present',
+  $default_locale    = undef,
+  $lc_ctype          = $locales::params::lc_ctype,
+  $lc_collate        = $locales::params::lc_collate,
+  $lc_time           = $locales::params::lc_time,
+  $lc_numeric        = $locales::params::lc_numeric,
+  $lc_monetary       = $locales::params::lc_monetary,
+  $lc_messages       = $locales::params::lc_messages,
+  $lc_paper          = $locales::params::lc_paper,
+  $lc_name           = $locales::params::lc_name,
+  $lc_address        = $locales::params::lc_address,
+  $lc_telephone      = $locales::params::lc_telephone,
+  $lc_measurement    = $locales::params::lc_measurement,
+  $lc_identification = $locales::params::lc_identification,
+  $autoupgrade       = false,
+  $package           = $locales::params::package,
+  $config_file       = $locales::params::config_file,
+  $locale_gen_cmd    = $locales::params::locale_gen_cmd,
+  $default_file      = $locales::params::default_file,
   $update_locale_pkg = $locales::params::update_locale_pkg,
   $update_locale_cmd = $locales::params::update_locale_cmd
 ) inherits locales::params {
@@ -95,16 +176,14 @@ class locales (
     notify  => Exec['locale-gen'],
   }
 
-  if $default_locale {
-    file { $default_file:
-      ensure  => $ensure,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template("${module_name}/locale.erb"),
-      require => $update_locale_require,
-      notify  => Exec['update-locale'],
-    }
+  file { $default_file:
+    ensure  => $ensure,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("${module_name}/locale.erb"),
+    require => $update_locale_require,
+    notify  => Exec['update-locale'],
   }
 
   exec { 'locale-gen':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,9 +7,21 @@ class locales::params {
 
   case $::operatingsystem {
     /(Ubuntu|Debian)/: {
-      $package = 'locales'
-      $default_file = '/etc/default/locale'
-      $locale_gen_cmd = '/usr/sbin/locale-gen'
+      $lc_ctype          = undef
+      $lc_collate        = undef
+      $lc_time           = undef
+      $lc_numeric        = undef
+      $lc_monetary       = undef
+      $lc_messages       = undef
+      $lc_paper          = undef
+      $lc_name           = undef
+      $lc_address        = undef
+      $lc_telephone      = undef
+      $lc_measurement    = undef
+      $lc_identification = undef
+      $package           = 'locales'
+      $default_file      = '/etc/default/locale'
+      $locale_gen_cmd    = '/usr/sbin/locale-gen'
       $update_locale_cmd = '/usr/sbin/update-locale'
 
       case $::lsbdistid {

--- a/templates/locale.erb
+++ b/templates/locale.erb
@@ -1,2 +1,40 @@
 # This file is managed by Puppet.
-LANG=<%= @default_locale %>
+<% if @default_locale -%>
+LANG="<%= @default_locale %>"
+<% end -%>
+<% if @lc_ctype -%>
+LC_CTYPE="<%= @lc_ctype %>"
+<% end -%>
+<% if @lc_collate -%>
+LC_COLLATE="<%= @lc_collate %>"
+<% end -%>
+<% if @lc_time -%>
+LC_TIME="<%= @lc_time %>"
+<% end -%>
+<% if @lc_numeric -%>
+LC_NUMERIC="<%= @lc_numeric %>"
+<% end -%>
+<% if @lc_monetary -%>
+LC_MONETARY="<%= @lc_monetary %>"
+<% end -%>
+<% if @lc_messages -%>
+LC_MESSAGES="<%= @lc_messages %>"
+<% end -%>
+<% if @lc_paper -%>
+LC_PAPER="<%= @lc_paper %>"
+<% end -%>
+<% if @lc_name -%>
+LC_NAME="<%= @lc_name %>"
+<% end -%>
+<% if @lc_address -%>
+LC_ADDRESS="<%= @lc_address %>"
+<% end -%>
+<% if @lc_telephone -%>
+LC_TELEPHONE="<%= @lc_telephone %>"
+<% end -%>
+<% if @lc_measurement -%>
+LC_MEASUREMENT="<%= @lc_measurement %>"
+<% end -%>
+<% if @lc_identification -%>
+LC_IDENTIFICATION="<%= @lc_identification %>"
+<% end -%>


### PR DESCRIPTION
Since there is only a very finite number of LC_\* variables (LC_CTYPE,
LC_TIME, ...) we create class parameter corresponding to their LC_*
equivalents which can be set by the user and end up in
/etc/default/locale. All $lc_\* parameters default to undef. This should
fix issue #13.
