### PR TITLE
Add support for LANGUAGE variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,6 +115,7 @@ class locales (
   $locales           = [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', ],
   $ensure            = 'present',
   $default_locale    = undef,
+  $language  = undef,
   $lc_ctype          = $locales::params::lc_ctype,
   $lc_collate        = $locales::params::lc_collate,
   $lc_time           = $locales::params::lc_time,

--- a/templates/locale.erb
+++ b/templates/locale.erb
@@ -2,6 +2,9 @@
 <% if @default_locale -%>
 LANG="<%= @default_locale %>"
 <% end -%>
+<% if @language -%>
+LANGUAGE="<%= @language %>"
+<% end -%>
 <% if @lc_ctype -%>
 LC_CTYPE="<%= @lc_ctype %>"
 <% end -%>


### PR DESCRIPTION
On a default ubuntu server install I have a variable LANGUAGE="en_US:en" in /etc/default/locale. That variable is missing from this module.
