### PR TITLE
All locales support 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,7 +179,6 @@ class locales (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('locales/locale.gen.erb'),
     require => Package[$package],
     notify  => Exec['locale-gen'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,7 +134,8 @@ class locales (
   $locale_gen_cmd    = $locales::params::locale_gen_cmd,
   $default_file      = $locales::params::default_file,
   $update_locale_pkg = $locales::params::update_locale_pkg,
-  $update_locale_cmd = $locales::params::update_locale_cmd
+  $update_locale_cmd = $locales::params::update_locale_cmd,
+  $supported_locales = $locales::params::supported_locales # ALL locales support
 ) inherits locales::params {
 
   case $ensure {
@@ -143,6 +144,12 @@ class locales (
         $package_ensure = 'latest'
       } else {
         $package_ensure = 'present'
+      }
+      # ALL locales support
+      if $locales == ['ALL'] {
+        $config_ensure = 'link'
+      } else {
+        $config_ensure = 'file'
       }
     }
     /(absent)/: {
@@ -166,15 +173,25 @@ class locales (
   } else {
     $update_locale_require = Package[$package]
   }
-
+  # ALL locales support
   file { $config_file:
-    ensure  => $ensure,
+    ensure  => $config_ensure,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => template('locales/locale.gen.erb'),
     require => Package[$package],
     notify  => Exec['locale-gen'],
+  }
+  # ALL locales support
+  if $locales == ['ALL'] {
+    File[$config_file] {
+      target => $supported_locales,
+    }
+  } else {
+    File[$config_file] {
+      content => template('locales/locale.gen.erb'),
+    }
   }
 
   file { $default_file:
@@ -192,6 +209,8 @@ class locales (
     refreshonly => true,
     path        => ['/usr/local/bin', '/usr/bin', '/bin', '/usr/local/sbin', '/usr/sbin', '/sbin'],
     require     => Package[$package],
+    #locale-gen with all locales may take a very long time
+    timeout     => 900,
   }
 
   exec { 'update-locale':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class locales::params {
       $default_file      = '/etc/default/locale'
       $locale_gen_cmd    = '/usr/sbin/locale-gen'
       $update_locale_cmd = '/usr/sbin/update-locale'
+      $supported_locales  = '/usr/share/i18n/SUPPORTED' # ALL locales support
 
       case $::lsbdistid {
         'Ubuntu': {


### PR DESCRIPTION
I'm planning to use thish usefoul module, unfortunately i have the needings of building all locales for some host i manage.

To accomplish it i've made some few rows that handle "ALL" keyword in the $locales config in the "debian way" making locales.gen as a link to /usr/share/i18n/SUPPORTED 

This also solves an issue i have wich raise "Ensure set to :present but file type is link so no content will be synced" if all locales was previously selected on the host.

Please consider it 