### PR TITLE
Suse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ for available LC_* environment variables and their descriptions:
 * package: string, default: OS specific. Set package name, if platform is not supported.
 * config_file: string, default: OS specific. Set config_file, if platform is not supported.
 * locale_gen_command: string, default: OS specific. Set locale_gen_command, if platform is not supported.
+* Suse specific:
+  * root_uses_lang: if set to 'ctype', root will be stay POSIX, set to 'yes' to change root to the global language as well. Defaults to 'ctype'.
+  * installed_languages: blank for english, otherwise space seperated list.  Used by Yast2 only.
+  * auto_detect_utf8: Workaround for missing forward of LANG and LC variables of e.g. ssh login connections.  Defaults to 'no'.
+  * input_method: A default input method to be used in X11. For more details see the comments at the top of /etc/X11/xim on a Suse system.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,31 +116,35 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class locales (
-  $locales           = [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', ],
-  $ensure            = 'present',
-  $default_locale    = undef,
-  $language  = undef,
-  $lc_ctype          = $locales::params::lc_ctype,
-  $lc_collate        = $locales::params::lc_collate,
-  $lc_time           = $locales::params::lc_time,
-  $lc_numeric        = $locales::params::lc_numeric,
-  $lc_monetary       = $locales::params::lc_monetary,
-  $lc_messages       = $locales::params::lc_messages,
-  $lc_paper          = $locales::params::lc_paper,
-  $lc_name           = $locales::params::lc_name,
-  $lc_address        = $locales::params::lc_address,
-  $lc_telephone      = $locales::params::lc_telephone,
-  $lc_measurement    = $locales::params::lc_measurement,
-  $lc_identification = $locales::params::lc_identification,
-  $lc_all            = $locales::params::lc_all,
-  $autoupgrade       = false,
-  $package           = $locales::params::package,
-  $config_file       = $locales::params::config_file,
-  $locale_gen_cmd    = $locales::params::locale_gen_cmd,
-  $default_file      = $locales::params::default_file,
-  $update_locale_pkg = $locales::params::update_locale_pkg,
-  $update_locale_cmd = $locales::params::update_locale_cmd,
-  $supported_locales = $locales::params::supported_locales # ALL locales support
+  $locales             = [ 'en_US.UTF-8 UTF-8', 'de_DE.UTF-8 UTF-8', ],
+  $ensure              = 'present',
+  $default_locale      = undef,
+  $language            = undef,
+  $lc_ctype            = $locales::params::lc_ctype,
+  $lc_collate          = $locales::params::lc_collate,
+  $lc_time             = $locales::params::lc_time,
+  $lc_numeric          = $locales::params::lc_numeric,
+  $lc_monetary         = $locales::params::lc_monetary,
+  $lc_messages         = $locales::params::lc_messages,
+  $lc_paper            = $locales::params::lc_paper,
+  $lc_name             = $locales::params::lc_name,
+  $lc_address          = $locales::params::lc_address,
+  $lc_telephone        = $locales::params::lc_telephone,
+  $lc_measurement      = $locales::params::lc_measurement,
+  $lc_identification   = $locales::params::lc_identification,
+  $lc_all              = $locales::params::lc_all,
+  $root_uses_lang      = $locales::params::root_uses_lang,
+  $installed_languages = $locales::params::installed_languages,
+  $auto_detect_utf8    = $locales::params::auto_detect_utf8,
+  $input_method        = $locales::params::input_method,
+  $autoupgrade         = false,
+  $package             = $locales::params::package,
+  $config_file         = $locales::params::config_file,
+  $locale_gen_cmd      = $locales::params::locale_gen_cmd,
+  $default_file        = $locales::params::default_file,
+  $update_locale_pkg   = $locales::params::update_locale_pkg,
+  $update_locale_cmd   = $locales::params::update_locale_cmd,
+  $supported_locales   = $locales::params::supported_locales # ALL locales support
 ) inherits locales::params {
 
   case $ensure {
@@ -209,13 +213,18 @@ class locales (
     }
 
   }
+  if $::osfamily == "Suse" {
+    $locale_template = "locale.suse.erb"
+  } else {
+    $locale_template = "locale.erb"
+  }
 
   file { $default_file:
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template("${module_name}/locale.erb"),
+    content => template("${module_name}/${locale_template}"),
     require => $update_locale_require,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,18 +1,23 @@
 # Default params for locales
 class locales::params {
-  $lc_ctype          = undef
-  $lc_collate        = undef
-  $lc_time           = undef
-  $lc_numeric        = undef
-  $lc_monetary       = undef
-  $lc_messages       = undef
-  $lc_paper          = undef
-  $lc_name           = undef
-  $lc_address        = undef
-  $lc_telephone      = undef
-  $lc_measurement    = undef
-  $lc_identification = undef
-  $lc_all            = undef
+  $lc_ctype            = undef
+  $lc_collate          = undef
+  $lc_time             = undef
+  $lc_numeric          = undef
+  $lc_monetary         = undef
+  $lc_messages         = undef
+  $lc_paper            = undef
+  $lc_name             = undef
+  $lc_address          = undef
+  $lc_telephone        = undef
+  $lc_measurement      = undef
+  $lc_identification   = undef
+  $lc_all              = undef
+  # Required for Suse - ignored for others
+  $root_uses_lang      = "ctype"  # if set to 'ctype', root will be stay POSIX, set to 'yes' to change root as well
+  $installed_languages = ""       # blank for english, otherwise space seperated list.  Used by Yast2 only.
+  $auto_detect_utf8    = "no"     # Workaround for missing forward of LANG and LC variables of e.g. ssh login connections.
+  $input_method        = ""       # A default input method to be used in X11. For more details see the comments at the top of /etc/X11/xim
 
   case $::operatingsystem {
     /(Ubuntu|Debian)/: {
@@ -64,6 +69,15 @@ class locales::params {
       } else {
         $default_file      = '/etc/sysconfig/i18n'
       }
+    }
+    /(SuSE|SLES)/ : {
+      $package = 'glibc-locale'
+      $default_file      = '/etc/sysconfig/language'
+      $local_gen_cmd = undef
+      $update_local_pkg = undef
+      $update_locale_cmd = undef
+      $config_file = undef
+      $update_locale_pkg = false
     }
     default: {
       fail("Unsupported platform: ${::operatingsystem}")

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,12 @@
       "operatingsystem": "Ubuntu"
     },
     {
+      "operatingsystem": "openSUSE"
+    },
+    {
+      "operatingsystem": "SLES"
+    },
+    {
       "operatingsystem": "CentOS"
     }
   ],

--- a/templates/locale.suse.erb
+++ b/templates/locale.suse.erb
@@ -1,0 +1,40 @@
+# This file is managed by Puppet.
+<% if @default_locale -%>
+RC_LANG="<%= @default_locale %>"
+<% end -%>
+<% if @lc_ctype -%>
+RC_LC_CTYPE="<%= @lc_ctype %>"
+<% end -%>
+<% if @lc_collate -%>
+RC_LC_COLLATE="<%= @lc_collate %>"
+<% end -%>
+<% if @lc_time -%>
+RC_LC_TIME="<%= @lc_time %>"
+<% end -%>
+<% if @lc_numeric -%>
+RC_LC_NUMERIC="<%= @lc_numeric %>"
+<% end -%>
+<% if @lc_monetary -%>
+RC_LC_MONETARY="<%= @lc_monetary %>"
+<% end -%>
+<% if @lc_messages -%>
+RC_LC_MESSAGES="<%= @lc_messages %>"
+<% end -%>
+<% if @lc_paper -%>
+RC_LC_PAPER="<%= @lc_paper %>"
+<% end -%>
+<% if @lc_all -%>
+RC_LC_ALL="<%= @lc_all %>"
+<% end -%>
+<% if @installed_languages -%>
+INSTALLED_LANGUAGES="<%= @installed_languages %>"
+<% end -%>
+<% if @root_uses_lang -%>
+ROOT_USES_LANG="<%= @root_uses_lang %>"
+<% end -%>
+<% if @auto_detect_utf8 -%>
+AUTO_DETECT_UTF8="<%= @auto_detect_utf8 %>"
+<% end -%>
+<% if @input_method -%>
+INPUT_METHOD="<%= @input_method %>"
+<% end -%>


### PR DESCRIPTION
Hi Steffen,
I'm adding Suse support with this pull request.  In summary:
  * I've added a new template for Suse as it prefixes RC_ onto all the LANG/LC vars plus it has a few extra settings which have reasonable defaults
  * Suse is more similar to Centos than Debian in that you just need to update a config file, but it seems to need a reboot to take a new setting for new logins.
  * I had to realign all the class parameters as I added a longer named variable - hence the large diff