### PR TITLE
local_gen_cmd should be locale_gen_cmd in params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,7 +62,7 @@ class locales::params {
     }
     /(RedHat|CentOS)/ : {
       $package = 'glibc-common'
-      $local_gen_cmd = undef
+      $locale_gen_cmd = undef
       $update_local_pkg = undef
       #$config_file = '/etc/locale.gen'
       $update_locale_cmd = undef
@@ -77,7 +77,7 @@ class locales::params {
     /(SuSE|SLES)/ : {
       $package = 'glibc-locale'
       $default_file      = '/etc/sysconfig/language'
-      $local_gen_cmd = undef
+      $locale_gen_cmd = undef
       $update_local_pkg = undef
       $update_locale_cmd = undef
       $config_file = undef


### PR DESCRIPTION
Just sending a patch for typographical error.