### PR TITLE
Added support for Fedora

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,24 +60,24 @@ class locales::params {
         }
       }
     }
-    /(RedHat|CentOS)/ : {
+    /(RedHat|CentOS|Fedora)/: {
       $package = 'glibc-common'
-      $local_gen_cmd = undef
+      $locale_gen_cmd = undef
       $update_local_pkg = undef
       #$config_file = '/etc/locale.gen'
       $update_locale_cmd = undef
       $config_file = '/var/lib/locales/supported.d/local'
       $update_locale_pkg = false
-      if $::operatingsystemmajrelease == '7' {
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $default_file      = '/etc/locale.conf'
       } else {
         $default_file      = '/etc/sysconfig/i18n'
       }
     }
-    /(SuSE|SLES)/ : {
+    /(SuSE|SLES)/: {
       $package = 'glibc-locale'
       $default_file      = '/etc/sysconfig/language'
-      $local_gen_cmd = undef
+      $locale_gen_cmd = undef
       $update_local_pkg = undef
       $update_locale_cmd = undef
       $config_file = undef


### PR DESCRIPTION
Hello,

We added support for Fedora and switched from operatingsystemmajrelease to versioncmp, due to the former test not working with Puppet 4. Tested with Fedora 25 and CentOS 6 and 7.

This request all incorporates the fixes @mdwheele made in request e555312.