### PR TITLE
Make sure $supported_locales is defined on CentOS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,6 +68,7 @@ class locales::params {
       $update_locale_cmd = undef
       $config_file = '/var/lib/locales/supported.d/local'
       $update_locale_pkg = false
+      $supported_locales = undef
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $default_file      = '/etc/locale.conf'
       } else {


### PR DESCRIPTION
```
Error: Evaluation Error: Unknown variable: 'locales::params::supported_locales'. at
/etc/puppetlabs/code/environments/vagrant/vendor/locales/manifests/init.pp:147:26
on node default.vagrant
```

This parameter is not actually used in init.pp, but needs to be defined anyway to prevent this evaluation error.