### PR TITLE
Fix file path for Archlinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,7 +85,7 @@ class locales::params {
       $package           = 'glibc'
       $update_locale_pkg = false
       $locale_gen_cmd    = '/usr/bin/locale-gen' # /usr/sbin will also work but considered legacy
-      $config_file       = '/etc/locales.gen'
+      $config_file       = '/etc/locale.gen'
       $default_file      = '/etc/locale.conf'
     }
     /(Gentoo|Sabayon)/: {


### PR DESCRIPTION
This corrects the path to the config file in Archlinux, allowing it to generate the required locales. Fixes #53 