### PR TITLE
Added support for Raspian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class locales::params {
   $input_method        = ''       # A default input method to be used in X11. For more details see the comments at the top of /etc/X11/xim
 
   case $::operatingsystem {
-    /(Ubuntu|Debian|LinuxMint)/: {
+    /(Ubuntu|Debian|LinuxMint|Raspbian)/: {
 
       $default_file      = '/etc/default/locale'
       $locale_gen_cmd    = '/usr/sbin/locale-gen'
@@ -44,7 +44,7 @@ class locales::params {
             $config_file = '/var/lib/locales/supported.d/local'
           }
         }
-        'Debian' : {
+        /(Debian|Raspbian)/: {
           $package = 'locales-all'
           # If config_file is not set, we will end up with the error message:
           # Missing title. The title expression resulted in undef at [init.pp

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,9 @@
   "issues_url": "https://github.com/saz/puppet-locales/issues",
   "operatingsystem_support": [
     {
+      "operatingsystem": "Raspbian"
+    },
+    {
       "operatingsystem": "Debian"
     },
     {


### PR DESCRIPTION
Raspbian is a slight variation on Debian that is now identified as a separate os in the v6 puppet agent.  This PR adds support for it.