### PR TITLE
Support Puppet 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 <7.0.0"
+      "version_requirement": ">=4.0.0 <8.0.0"
     }
   ],
   "description": "Manage locales on Linux",


### PR DESCRIPTION
Without this certain software like Kafo will choke with an error message when trying to run with Puppet 7.