### PR TITLE
Add support for AlmaLinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,7 +60,7 @@ class locales::params {
         }
       }
     }
-    /(RedHat|CentOS|OracleLinux|Fedora|Amazon|CloudLinux)/: {
+    /(RedHat|CentOS|OracleLinux|Fedora|Amazon|CloudLinux|AlmaLinux)/: {
       $package = 'glibc-common'
       $update_locale_pkg = false
       $locale_gen_cmd = undef


### PR DESCRIPTION
As it's another 1:1 clone of RHEL - like CentOS, just adding it to the list is enough.