### PR TITLE
Add support to Debian 12 and Ubuntu 24.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,22 @@ class locales::params {
 
   case $facts['os']['name'] {
     /(Ubuntu|Debian|LinuxMint|Linuxmint|Raspbian|Kali|Pop!_OS)/: {
-      $default_file      = '/etc/default/locale'
+      case $facts['os']['name'] {
+        'Debian': {
+          if versioncmp($facts['os']['release']['full'], '12') >= 0 {
+            $default_file = '/etc/locale.conf'
+          }
+        }
+        'Ubuntu': {
+          if versioncmp($facts['os']['release']['full'], '24.04') >= 0 {
+            $default_file = '/etc/locale.conf'
+          }
+        }
+        default: {
+          $default_file = '/etc/default/locale'
+        }
+      }
+
       $locale_gen_cmd    = '/usr/sbin/locale-gen'
       $update_locale_cmd = '/usr/sbin/update-locale'
       $supported_locales = '/usr/share/i18n/SUPPORTED' # ALL locales support


### PR DESCRIPTION
Testet on Ubuntu 22.04.

Fixes #69 .

Default condition can be changed when all Debian-flavored distributions are added with the right version.